### PR TITLE
feat: graphql teaser online service feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">=8.1 <8.5.0",
+        "atoolo/graphql-search-bundle": "dev-main",
         "atoolo/search-bundle": "^1.0",
         "symfony/config": "^6.3 || ^7.0",
         "symfony/dependency-injection": "^6.3 || ^7.0",

--- a/config/graphql.yaml
+++ b/config/graphql.yaml
@@ -1,0 +1,14 @@
+overblog_graphql:
+  definitions:
+    schema:
+      query: RootQuery
+      mutation: RootMutation
+      types: [OnlineServiceFeature]
+    mappings:
+      types:
+      - type: attribute
+        dir: "%atoolo_citygov.src_dir%/Service/GraphQL/Types"
+        suffix: ~
+      - types: [yaml]
+        dir: "%atoolo_citygov.config_dir%/graphql/types"
+        suffix: ~

--- a/config/graphql/types/Others.type.yml
+++ b/config/graphql/types/Others.type.yml
@@ -1,0 +1,5 @@
+OnlineServiceFeature:
+  type: "object"
+  inherits: [TeaserFeature]
+  config:
+    interfaces: [TeaserFeature]

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,3 +28,10 @@ services:
   Atoolo\CityGov\Service\Indexer\Enricher\SiteKitSchema2x\ContactPointDocumentEnricher:
     tags:
       - { name: 'atoolo_search.indexer.document_enricher.schema2x', priority: 9 }
+
+  # GraphQL
+
+  atoolo_citygov.graphql.factory.online_service_feature:
+    class: Atoolo\CityGov\Service\GraphQL\Factory\OnlineServiceFeatureFactory
+    tags:
+      - { name: 'atoolo_graphql_search.teaser_feature_factory' }

--- a/src/AtooloCityGovBundle.php
+++ b/src/AtooloCityGovBundle.php
@@ -18,7 +18,15 @@ class AtooloCityGovBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
+        $container->setParameter(
+            'atoolo_citygov.src_dir',
+            __DIR__,
+        );
         $configDir = __DIR__ . '/../config';
+        $container->setParameter(
+            'atoolo_citygov.config_dir',
+            $configDir,
+        );
 
         $loader = new GlobFileLoader(new FileLocator($configDir));
         $loader->setResolver(
@@ -28,7 +36,7 @@ class AtooloCityGovBundle extends Bundle
                 ],
             ),
         );
-
+        $loader->load('graphql.yaml');
         $loader->load('services.yaml');
     }
 }

--- a/src/Service/GraphQL/Factory/OnlineServiceFeatureFactory.php
+++ b/src/Service/GraphQL/Factory/OnlineServiceFeatureFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\CityGov\Service\GraphQL\Factory;
+
+use Atoolo\CityGov\Service\GraphQL\Types\OnlineServiceFeature;
+use Atoolo\GraphQL\Search\Factory\TeaserFeatureFactory;
+use Atoolo\GraphQL\Search\Types\TeaserFeature;
+use Atoolo\Resource\Resource;
+
+class OnlineServiceFeatureFactory implements TeaserFeatureFactory
+{
+    /**
+     * @return TeaserFeature[]
+     */
+    public function create(
+        Resource $resource,
+    ): array {
+        $onlineServiceFeatures = [];
+        if ($resource->data->has('metadata.citygovProduct.onlineServices')) {
+            $onlineServiceFeatures[] = new OnlineServiceFeature();
+        }
+        return $onlineServiceFeatures;
+    }
+}

--- a/src/Service/GraphQL/Types/OnlineServiceFeature.php
+++ b/src/Service/GraphQL/Types/OnlineServiceFeature.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\CityGov\Service\GraphQL\Types;
+
+use Atoolo\GraphQL\Search\Types\TeaserFeature;
+
+/**
+ * @codeCoverageIgnore
+ */
+class OnlineServiceFeature extends TeaserFeature {}

--- a/test/Service/GraphQL/Factory/OnlineServiceFeatureFactoryTest.php
+++ b/test/Service/GraphQL/Factory/OnlineServiceFeatureFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\CityGov\Test\Service\GraphQL\Factory;
+
+use Atoolo\CityGov\Service\GraphQL\Factory\OnlineServiceFeatureFactory;
+use Atoolo\CityGov\Service\GraphQL\Types\OnlineServiceFeature;
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceLanguage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnlineServiceFeatureFactory::class)]
+class OnlineServiceFeatureFactoryTest extends TestCase
+{
+    private OnlineServiceFeatureFactory $factory;
+
+    public function setUp(): void
+    {
+        $this->factory = new OnlineServiceFeatureFactory();
+    }
+
+    public function testCreate()
+    {
+        $resource = $this->createResource([
+            'metadata' => [
+                'citygovProduct' => [
+                    'onlineServices' => [
+                        'some' => 'data',
+                    ],
+                ],
+            ],
+        ]);
+        $onlineServiceFeatures = $this->factory->create($resource);
+        $this->assertInstanceOf(
+            OnlineServiceFeature::class,
+            $onlineServiceFeatures[0],
+        );
+    }
+
+    public function testCreateFail()
+    {
+        $resource = $this->createResource([
+            'metadata' => [
+                'citygovProduct' => [
+                    'no_online' => 'services',
+                ],
+            ],
+        ]);
+        $onlineServiceFeatures = $this->factory->create($resource);
+        $this->assertEmpty($onlineServiceFeatures);
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function createResource(array $data): Resource
+    {
+        return new Resource(
+            $data['url'] ?? '',
+            $data['id'] ?? '',
+            $data['name'] ?? '',
+            $data['objectType'] ?? '',
+            ResourceLanguage::default(),
+            new DataBag($data),
+        );
+    }
+}


### PR DESCRIPTION
- adds graphql dependency and basic config
- adds graphql type `OnlineServiceFeature`
- adds factory `OnlineServiceFeatureFactory`

**For context:** 
In [graphql-search-bundle](https://github.com/sitepark/atoolo-graphql-search-bundle), the graphql types for teasers `ArticleTeaser`, `MediaTeaser` and `NewsTeaser` have a new field `feature` which has the type `[TeaserFeature!]!` (see [here](https://github.com/sitepark/atoolo-graphql-search-bundle/blob/main/config/graphql/decorators/ArticleTeaser.decorator.yaml#L35)).
The `TeaserFeature` type is an interface that only consists of an optional label. Additional fields like `link` could be added on sub types. 

The new type `OnlineServiceFeature` is an implementation of `TeaserFeature`. For now, `OnlineServiceFeature` has no additional field. The frontend currently needs no additional information other than that there _is_ an online service available. We can always go and add more fields later though.

Then there's the `OnlineServiceFeatureFactory` that implements [`TeaserFeatureFactory`](https://github.com/sitepark/atoolo-graphql-search-bundle/blob/main/src/Factory/TeaserFeatureFactory.php) and is a service tagged with  `atoolo_graphql_search.teaser_feature_factory`. This factory creates `OnlineServiceFeature`s which will automatically be collected by the teasers `ArticleTeaser` etc., as long as they're not null.

Currently, the factory only checks whether the field `metadata.citygovProduct.onlineServices` exists on a resource and uses this as an indicator to create a `OnlineServiceFeature`. Is this correct? 