### PR TITLE
feat(OnlineServiceFeature): use linkfactory for online service link

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -37,6 +37,9 @@ services:
   # GraphQL
   atoolo_citygov.graphql.factory.online_service_feature:
     class: Atoolo\CityGov\Service\GraphQL\Factory\OnlineServiceFeatureFactory
+    arguments:
+      - '@atoolo_resource.navigation_hierarchy_loader'
+      - '@atoolo_graphql_search.factory.link_factory'
     tags:
       - { name: 'atoolo_graphql_search.teaser_feature_factory' }
 

--- a/test/Service/GraphQL/Factory/OnlineServiceFeatureFactoryTest.php
+++ b/test/Service/GraphQL/Factory/OnlineServiceFeatureFactoryTest.php
@@ -7,11 +7,14 @@ namespace Atoolo\CityGov\Test\Service\GraphQL\Factory;
 use Atoolo\CityGov\Service\GraphQL\Factory\OnlineServiceFeatureFactory;
 use Atoolo\CityGov\Service\GraphQL\Types\OnlineService;
 use Atoolo\CityGov\Service\GraphQL\Types\OnlineServiceFeature;
+use Atoolo\GraphQL\Search\Factory\LinkFactory;
 use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\Resource\DataBag;
 use Atoolo\Resource\Resource;
 use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Resource\ResourceLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(OnlineServiceFeatureFactory::class)]
@@ -19,13 +22,25 @@ class OnlineServiceFeatureFactoryTest extends TestCase
 {
     private OnlineServiceFeatureFactory $factory;
 
+    private ResourceLoader&MockObject $resourceLoader;
+
+    private LinkFactory&MockObject $linkFactory;
+
     public function setUp(): void
     {
-        $this->factory = new OnlineServiceFeatureFactory();
+        $this->resourceLoader = $this->createMock(ResourceLoader::class);
+        $this->linkFactory = $this->createMock(LinkFactory::class);
+        $this->factory = new OnlineServiceFeatureFactory(
+            $this->resourceLoader,
+            $this->linkFactory,
+        );
     }
 
     public function testCreate()
     {
+        $onlineServiceResource = $this->createResource([]);
+        $onlineServiceResourceUrl =  '/path/to/online/service';
+        $onlineServiceResourceLink = new Link($onlineServiceResourceUrl);
         $resource = $this->createResource([
             'metadata' => [
                 'citygovProduct' => [
@@ -33,18 +48,27 @@ class OnlineServiceFeatureFactoryTest extends TestCase
                         'some' => 'data',
                         'serviceList' => [
                             'items' => [[
-                                'url' => '/path/to/online/service',
+                                'url' => $onlineServiceResourceUrl,
                             ]],
                         ],
                     ],
                 ],
             ],
         ]);
+        $this->resourceLoader
+            ->method('load')
+            ->with($onlineServiceResourceUrl)
+            ->willReturn($onlineServiceResource);
+        $this->linkFactory
+            ->method('create')
+            ->with($onlineServiceResource)
+            ->willReturn($onlineServiceResourceLink);
+
         $onlineServiceFeatures = $this->factory->create($resource);
         $this->assertEquals(
             new OnlineServiceFeature(
                 null,
-                [new OnlineService(new Link('/path/to/online/service'))],
+                [new OnlineService($onlineServiceResourceLink)],
             ),
             $onlineServiceFeatures[0],
         );


### PR DESCRIPTION
Resolve the link of an online service by loading the underlying resource and using the `Atoolo\GraphQL\Search\Factory\LinkFactory` 