### PR TITLE
fix: change field for phonumber

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -75,7 +75,7 @@ services:
   atoolo_citygov.search.solr_suggest_citygov_person_phonenumber:
     class: Atoolo\Search\Service\Search\SolrSuggest
     factory: [ '@atoolo_citygov.search.solr_suggest_factory', 'createForSolrField' ]
-    arguments: ['sp_citygov_phonenumber']
+    arguments: ['sp_citygov_phone']
   
   atoolo_citygov.search.solr_suggest_citygov_person_address:
     class: Atoolo\Search\Service\Search\SolrSuggest


### PR DESCRIPTION
The field sp_citygov_phonenumber is not preset in schema 2.1

https://gitlab.sitepark.com/ies-modules/solr/-/blob/develop/solr-server/src/main/resources/schema/default/2.1/schema-fields-general.xml#L93